### PR TITLE
rs988: Don't let builds complete without vendor tree

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -29,4 +29,4 @@ TARGET_KERNEL_CONFIG := lineageos_rs988_defconfig
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 25174212608
 
 # inherit from the proprietary version
--include vendor/lge/rs988/BoardConfigVendor.mk
+include vendor/lge/rs988/BoardConfigVendor.mk

--- a/device.mk
+++ b/device.mk
@@ -18,7 +18,7 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 
 # Get non-open-source specific aspects
-$(call inherit-product-if-exists, vendor/lge/rs988/rs988-vendor.mk)
+$(call inherit-product, vendor/lge/rs988/rs988-vendor.mk)
 
 # Properties
 -include $(LOCAL_PATH)/vendor_prop.mk


### PR DESCRIPTION
* There is zero reason to ever build without blobs. We've even seen
  this situation with official builds from our servers. It's always
  better for a build to fail than it is for it to produce something
  that has no chance at working.

Change-Id: I4968795670c91f691e9ecdc0e4af62e16ba3a93a